### PR TITLE
[FIX] use relative import

### DIFF
--- a/odooup/init.py
+++ b/odooup/init.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from distutils.spawn import find_executable
 
 import click
-from clone import clone_submodule_to_target, get_vendor_target
+from .clone import clone_submodule_to_target, get_vendor_target
 
 from ._helpers import call_cmd, replace_in_file
 from ._installers import install_compose_impersonation, install_make, install_precommit


### PR DESCRIPTION
```bash
$ odooup init
Warning: entry point could not be loaded. Contact its author for help.


Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/click_plugins/core.py", line 37, in decorator
    group.add_command(entry_point.load())
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.5/dist-packages/odooup/init.py", line 9, in <module>
    from clone import clone_submodule_to_target, get_vendor_target
ImportError: No module named 'clone'
```

Python 3.5.2 on ubuntu xenial